### PR TITLE
fix(animation-manager): "avoid animation" is set incorrectly if fallback …

### DIFF
--- a/applications/services/desktop/animations/animation_manager.c
+++ b/applications/services/desktop/animations/animation_manager.c
@@ -388,13 +388,28 @@ static StorageAnimation*
     uint32_t whole_weight = 0;
 
     bool fallback = xtreme_settings.fallback_anim;
+    bool unlock = xtreme_settings.unlock_anims;
+
+    uint32_t valid_animations = 0;
+    for
+        M_EACH(item, animation_list, StorageAnimationList_t) {
+            const StorageAnimationManifestInfo* manifest_info = animation_storage_get_meta(*item);
+            bool valid = animation_manager_is_valid_idle_animation(manifest_info, &stats, unlock);
+            if(valid) {
+                valid_animations += 1;
+            };
+        }
+
+    if(valid_animations <= 2 && !fallback) {
+        avoid_animation = NULL;
+    }
+
     if(StorageAnimationList_size(animation_list) == dolphin_internal_size + 1 && !fallback) {
         // One ext anim and fallback disabled, dont skip current anim (current = only ext one)
         avoid_animation = NULL;
     }
 
     StorageAnimationList_it_t it;
-    bool unlock = xtreme_settings.unlock_anims;
     for(StorageAnimationList_it(it, animation_list); !StorageAnimationList_end_p(it);) {
         StorageAnimation* storage_animation = *StorageAnimationList_ref(it);
         const StorageAnimationManifestInfo* manifest_info =


### PR DESCRIPTION
…is enabled and the user has only one or less available animation

# What's new

I had the issue that even with "Credits Anim" set to OFF. I saw from time to time the thank you animation. The problem was that the avoid_animation string was not set to NULL properly.

Now i am just looping over the animation list and count how many valid animations the user has. If this is less then 2 i clear the avoid_animation variable.

I am not quiet sure what this line is doing:
`if(StorageAnimationList_size(animation_list) == dolphin_internal_size + 1 && !fallback) {`

because for me it was checking if 27(animation list size) is equal to 3(dolphin internal size), so this branch was never reached in my case. But unfortunately I could not find out where dolphin_internal_size comes from.

This is my first MR ever to an open source project so i hope everything is fine so far.

-----
# For the reviewer

- [ ] I've uploaded the firmware with this patch to a device and verified its functionality
- [ ] I've confirmed the bug to be fixed / feature to be stable
